### PR TITLE
Lifetime of .data() has changed on GCC 5

### DIFF
--- a/hiredispp.h
+++ b/hiredispp.h
@@ -335,7 +335,7 @@ namespace hiredispp
         RedisCommandBase(const RedisCommandBase<CharT>& from)
             : _parts(from._parts) { }
 
-        std::string operator[](size_t i) const
+        const std::string& operator[](size_t i) const
         {
             return _parts[i];
         }


### PR DESCRIPTION
beginCommand() inccorectly uses data() in a loop, because the lifetime is not guaranteed after the loop (in fact, even after the instruction). This also applies to c_str().